### PR TITLE
fix: lockup upstream dependencies of `@rc-component/color-picker`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@ctrl/tinycolor": "^4",
-    "@rc-component/color-picker": "^1.4.1"
+    "@rc-component/color-picker": "1.5.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^4
         version: 4.1.0
       '@rc-component/color-picker':
-        specifier: ^1.4.1
-        version: 1.6.0(react-dom@18.3.1)(react@18.3.1)
+        specifier: 1.5.3
+        version: 1.5.3(react-dom@18.3.1)(react@18.3.1)
     optionalDependencies:
       dumi:
         specifier: ^2
@@ -115,13 +115,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
-
-  /@ant-design/fast-color@1.2.0:
-    resolution: {integrity: sha512-CgyH14PfGOTE2eggjzgw3xznhYP3sXmcVxIjm0xTbYr2y8BgsrIjt6byQ9UJDws2j6p7rEwzep+Hmt179Esb0w==}
-    engines: {node: '>=8.x'}
-    dependencies:
-      '@babel/runtime': 7.24.7
-    dev: false
 
   /@ant-design/icons-svg@4.4.2:
     resolution: {integrity: sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==}
@@ -852,6 +845,11 @@ packages:
       postcss-selector-parser: ^6.0.13
     dependencies:
       postcss-selector-parser: 6.1.0
+
+  /@ctrl/tinycolor@3.6.1:
+    resolution: {integrity: sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==}
+    engines: {node: '>=10'}
+    dev: false
 
   /@ctrl/tinycolor@4.1.0:
     resolution: {integrity: sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ==}
@@ -1942,7 +1940,7 @@ packages:
     peerDependencies:
       react: '>=16.3.0'
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.24.7
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
       react-is: 16.13.1
@@ -2171,15 +2169,15 @@ packages:
       config-chain: 1.1.13
     dev: true
 
-  /@rc-component/color-picker@1.6.0(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-kB6QVTWOR80ZiKuD86Y1EXkvQtTkO2w4Oxnjkb/peMXgWfh/U/Em3K5EREZfioioiouWiEZ7oInI5/JEKoqaRA==}
+  /@rc-component/color-picker@1.5.3(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-+tGGH3nLmYXTalVe0L8hSZNs73VTP5ueSHwUlDC77KKRaN7G4DS4wcpG5DTDzdcV/Yas+rzA6UGgIyzd8fS4cw==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
-      '@ant-design/fast-color': 1.2.0
       '@babel/runtime': 7.24.7
-      classnames: 2.5.1
+      '@ctrl/tinycolor': 3.6.1
+      classnames: 2.3.2
       rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -3424,7 +3422,7 @@ packages:
   /@umijs/history@5.3.1:
     resolution: {integrity: sha512-/e0cEGrR2bIWQD7pRl3dl9dcyRGeC9hoW0OCvUTT/hjY0EfUrkd6G8ZanVghPMpDuY5usxq9GVcvrT8KNXLWvA==}
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.24.7
       query-string: 6.14.1
 
   /@umijs/lint@4.3.1(eslint@8.57.0)(stylelint@14.16.1)(typescript@5.5.3):
@@ -4812,10 +4810,6 @@ packages:
 
   /classnames@2.3.2:
     resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
-
-  /classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
-    dev: false
 
   /clean-css@5.3.3:
     resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
@@ -7791,7 +7785,7 @@ packages:
   /history@5.3.0:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.24.7
 
   /hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
@@ -11851,7 +11845,7 @@ packages:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.24.7
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.3.1


### PR DESCRIPTION
reason: https://github.com/react-component/color-picker/pull/255

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- \[ ] feat
- \[x] fix
- \[ ] style
- \[ ] chore
- \[ ] docs

#### 🔀 变更说明 | Description of Change

上游 `@rc-component/color-picker` 在 https://github.com/react-component/color-picker/pull/255 提交中为了减少体积，缩减了一些判断，但是当前仓库使用 `@ctrl/tinycolor` 可能更合适...

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
